### PR TITLE
Scheduled Pipelines are not yet available in 3.x

### DIFF
--- a/jekyll/_cci2/scheduled-pipelines.md
+++ b/jekyll/_cci2/scheduled-pipelines.md
@@ -6,7 +6,6 @@ description: "Learn how to schedule pipelines for your CircleCI projects."
 order: 20
 version:
 - Cloud
-- Server v3.x
 suggested:
   - title: Manual job approval and scheduled workflow runs
     link: https://circleci.com/blog/manual-job-approval-and-scheduled-workflow-runs/


### PR DESCRIPTION
# Description
Scheduled pipelines are not yet available in Server 3.x and will not be available until 3.4. This needs to be accurately reflected in our Docs page.

# Reasons
Received a question from a customer about Scheduled Pipelines not being available in their installation. They noticed that the feature is being [listed as available in Server 3](https://circleci.com/docs/2.0/scheduled-pipelines/#overview) in our docs page. 